### PR TITLE
Removal of redundant check in onKick function 

### DIFF
--- a/core-contracts/Delegation/src/main/java/finance/omm/score/core/delegation/DelegationImpl.java
+++ b/core-contracts/Delegation/src/main/java/finance/omm/score/core/delegation/DelegationImpl.java
@@ -227,9 +227,6 @@ public class DelegationImpl extends AddressProvider implements Delegation {
     public void onKick(Address user, BigInteger bOMMUserBalance, @Optional byte[] data) {
         onlyOrElseThrow(Contracts.BOOSTED_OMM,
                 DelegationException.unauthorized("Only bOMM contract is allowed to call onKick method"));
-        if (!bOMMUserBalance.equals(BigInteger.ZERO)) {
-            throw DelegationException.unknown(user + " OMM locking has not expired");
-        }
         updateUserDelegations(null, user, bOMMUserBalance);
         UserKicked(user, data);
     }

--- a/core-contracts/RewardDistribution/src/main/java/finance/omm/score/core/reward/distribution/RewardDistributionImpl.java
+++ b/core-contracts/RewardDistribution/src/main/java/finance/omm/score/core/reward/distribution/RewardDistributionImpl.java
@@ -430,9 +430,6 @@ public class RewardDistributionImpl extends AbstractRewardDistribution {
         onlyOrElseThrow(Contracts.BOOSTED_OMM,
                 RewardDistributionException.unauthorized("Only bOMM contract is allowed to call onKick method"));
 
-        if (!bOMMUserBalance.equals(BigInteger.ZERO)) {
-            throw RewardDistributionException.unknown(user + " OMM locking has not expired");
-        }
         BigInteger bOMMTotalSupply = getBOMMTotalSupply();
 
         List<Address> assets = this.assets.keySet(this.platformRecipientMap.keySet());


### PR DESCRIPTION
The bOMM balance check on onKick function is removed from reward distribution and delegation contract.