### PR TITLE
Java Map Data Retrieval from getOrDefault 

### DIFF
--- a/core-contracts/Staking/src/main/java/finance/omm/score/staking/StakingImpl.java
+++ b/core-contracts/Staking/src/main/java/finance/omm/score/staking/StakingImpl.java
@@ -364,7 +364,11 @@ public class StakingImpl implements Staking {
 
         for (String prep : actualPrepDelegations.keySet()) {
                     if (topPreps.contains(Address.fromString(prep))) {
-                       BigInteger amount = allPrepDelegations.getOrDefault(prep, BigInteger.ZERO);
+                        //  Unsupported JCL method: getOrDefault in java.util.Map
+                       BigInteger amount = allPrepDelegations.get(prep);
+                       if (amount == null){
+                           continue;
+                       }
                        allPrepDelegations.put(prep, amount.add(actualPrepDelegations.get(prep)));
                     }
         }


### PR DESCRIPTION
To address the lack of support for ``getOrDefault()`` when fetching data from java.util.Map, an alternative approach is employed. The data is retrieved using the `get()` and subsequently, the fetched value is examined for null to catch any potential NullPointerException